### PR TITLE
Fix non-ASCII menu item handling

### DIFF
--- a/appindicator.el
+++ b/appindicator.el
@@ -161,7 +161,7 @@ PROC-BUFFER should be process buffer used by helper."
         (message "emacs-appindicator: garbage in process buffer!")
         (delete-region (point-min) (match-beginning 0)))
 
-      (when (> (- (point-max) (point)) sexpsz)
+      (when (> (- (position-bytes (point-max)) (position-bytes (point))) sexpsz)
         (let ((value (read (current-buffer))))
           (prog1
               value


### PR DESCRIPTION
Hello! When trying to display my org-agenda items in the menu, I found that it didn't always call the callback when the text contains non-ASCII text. Here is a simple fix for it. Also, thank you for your work!